### PR TITLE
Critical bugfixes for seemingly abandoned AdaptiveIndexDefrag

### DIFF
--- a/AdaptiveIndexDefrag/CHANGELOG.txt
+++ b/AdaptiveIndexDefrag/CHANGELOG.txt
@@ -144,3 +144,10 @@ v1.6.6.9 - 06/26/2019 - Fixed issues running in Azure SQL Database.
 v1.6.7 - 09/19/2019 - Added additional debug info;
 			Fixed additional issues running in Azure SQL Database;
 			Fixed issue with resumable index discovery on SQL Server 2017+.
+v1.6.8 - 2024-08-30 - Bugfix update statistics because of quotenames, as programmed in https://github.com/AndrewG2/tigertoolbox/commit/00fef9a645e7f6880557cf59692b59f6da1a58c1
+v1.6.9 - 2024-08-30 - Adding schema-names in the debug output & logging output
+v1.7.0 - 2024-09-02 - Fix update-stats for tables with more than 10B changes since last update-stats
+                        Fix duration calculation
+                        Fix logging update-stats of table id, schema name and table name
+v1.7.1 - 2024-09-10 - Fix for bug in official release : proactive fix for rebuilding indexes which have spaces in index names
+                        Fix for bug introduced in v1.7.0: for those indexes rebuilt, the stats_log table had a null-value for objectId & objectName


### PR DESCRIPTION
v1.6.8 - 2024-08-30
* Bugfix update statistics because of quotenames, as programmed in https://github.com/AndrewG2/tigertoolbox/commit/00fef9a645e7f6880557cf59692b59f6da1a58c1

v1.6.9 - 2024-08-30
* Adding schema-names in the debug output & logging output

v1.7.0 - 2024-09-02
* Fix update-stats for tables with more than 10B changes since last update-stats
* Fix duration calculation
* Fix logging update-stats of table id, schema name and table name

v1.7.1 - 2024-09-10
* Fix for bug in official release : proactive fix for rebuilding indexes which have spaces in index names
* Fix for bug introduced in v1.7.0: for those indexes rebuilt, the stats_log table had a null-value for objectId & objectName